### PR TITLE
Fix plugin_sysctl for tuned 2.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN INSTALL_PKGS=" \
     ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n hdparm kernel-tools ; fi) && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS $ARCH_DEP_PKGS && \
     rpm -V $INSTALL_PKGS $ARCH_DEP_PKGS && \
-    (LC_COLLATE=C cat patches/*.diff | patch -p1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
+    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
     touch /etc/sysctl.conf && \
     yum -y remove patch && \
     yum clean all && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -16,7 +16,7 @@ RUN INSTALL_PKGS=" \
     ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n hdparm kernel-tools ; fi) && \
     yum install --setopt=tsflags=nodocs -y $INSTALL_PKGS $ARCH_DEP_PKGS && \
     rpm -V $INSTALL_PKGS $ARCH_DEP_PKGS && \
-    (LC_COLLATE=C cat patches/*.diff | patch -p1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
+    (LC_COLLATE=C cat patches/*.diff | patch -Np1 -d /usr/lib/python*/site-packages/tuned/ || :) && \
     touch /etc/sysctl.conf && \
     yum -y remove patch && \
     yum clean all && \

--- a/assets/patches/020-traceback_with_modifiers.diff
+++ b/assets/patches/020-traceback_with_modifiers.diff
@@ -1,0 +1,32 @@
+Remove this fix once https://github.com/redhat-performance/tuned/commit/a8f2a8306e1bac6cfc739e6753d381bf509c995e is productized.
+
+plugin_sysctl: fixed traceback with modifiers '>', '<' and orig==new
+
+It fixed the following problem e.g. the profile:
+[sysctl]
+kernel.pid_max=>131072
+
+and if kernel.pid_max is already 131072 Tuned shows traceback.
+
+Resolves: rhbz#1739418
+
+diff --git a/plugins/plugin_sysctl.py b/plugins/plugin_sysctl.py
+index bcaead29..b298bfa8 100644
+--- a/plugins/plugin_sysctl.py
++++ b/plugins/plugin_sysctl.py
+@@ -54,12 +54,13 @@ def _instance_apply_static(self, instance):
+ 				log.error("sysctl option %s will not be set, failed to read the original value."
+ 						% option)
+ 			else:
+-				instance._sysctl_original[option] = original_value
+ 				new_value = self._variables.expand(
+ 						self._cmd.unquote(value))
+ 				new_value = self._process_assignment_modifiers(
+ 						new_value, original_value)
+-				_write_sysctl(option, new_value)
++				if new_value is not None:
++					instance._sysctl_original[option] = original_value
++					_write_sysctl(option, new_value)
+ 
+ 		storage_key = self._storage_key(instance.name)
+ 		self._storage.set(storage_key, instance._sysctl_original)


### PR DESCRIPTION
Tuned 2.11 prior to commit a8f2a830 doesn't handle sysctl plugin with '<' '>' modifiers properly resulting in program traceback and malfunction (see RH BZ1739418 for detail).

This PR adds a patch for tuned to address the issue.