### PR TITLE
Fix comparison on stopping tuned

### DIFF
--- a/assets/bin/run
+++ b/assets/bin/run
@@ -27,7 +27,7 @@ stop() {
   local timeout=10	# wait $timeout [s] for a reply via the socket
   local response=$(echo stop | socat -t$timeout - UNIX-CONNECT:$openshift_tuned_socket 2>/dev/null)
 
-  if "$response" != "ok"; then
+  if [ "$response" != "ok" ]; then
     # provide a failure message in the event log
     echo "openshift-tuned stop response: $response" 1>&2
     return 1


### PR DESCRIPTION
Currently this fails because string comparison
misses the square brackets.