### PR TITLE
Do not use systemctl for checks inside chroot

### DIFF
--- a/assets/patches/010-reload-on-hup.diff
+++ b/assets/patches/010-reload-on-hup.diff
@@ -29,3 +29,13 @@ Remove this fix once https://github.com/redhat-performance/tuned/pull/143 is pro
  	def _init_profile(self, profile_names):
  		manual = True
  		if profile_names is None:
+@@ -117,6 +117,9 @@
+ 		return errstr
+ 
+ 	def _full_rollback_required(self):
++                # if we are in chroot, we cannot use systemctl
++                if [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ]:
++                    return False
+ 		retcode, out = self._cmd.execute(["systemctl", "is-system-running"], no_errors = [0])
+ 		if retcode < 0:
+ 			return False


### PR DESCRIPTION
All the systemctl commands used for that rollback
check are not valid inside a chroot. So just avoid
them and return false, to prevent unwanted rollbacks.