### PR TITLE
Switch the base image from origin-v4.0 to centos:7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/openshift-tuned
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM centos:7
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}


### PR DESCRIPTION
With the switch of origin-v4.0 to UBI from centos, the upstream image no longer builds due to additional dependencies that cannot be fetched.  Use centos:7 as base for the upstream image which has all the dependencies.