### PR TITLE
Allow systemctl run in chroot()ed environment.

### DIFF
--- a/assets/bin/run
+++ b/assets/bin/run
@@ -3,9 +3,10 @@
 cluster_node_labels=${CLUSTER_NODE_LABELS:-/var/lib/tuned/ocp-node-labels.cfg}
 cluster_pod_labels=${CLUSTER_POD_LABELS:-/var/lib/tuned/ocp-pod-labels.cfg}
 openshift_tuned_socket=/var/lib/tuned/openshift-tuned.sock
+export SYSTEMD_IGNORE_CHROOT=1
 
 start() {
-  SYSTEMD_IGNORE_CHROOT=1 systemctl disable tuned --now || :
+  systemctl disable tuned --now || :
 
   # Tuned can take ~20s to reload/start when "ulimit -Sn == 1048576".
   # See:


### PR DESCRIPTION
Some code in the tuned daemon relies on running systemctl commands. Export `SYSTEMD_IGNORE_CHROOT=1` so that it is visible to the systemctl commands inside the tuned daemon.

See https://github.com/redhat-performance/tuned/pull/197 for detail.