### PR TITLE
Support for the "rendered" Tuned CR.

### DIFF
--- a/vendor/github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1/tuned_types.go
+++ b/vendor/github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1/tuned_types.go
@@ -8,11 +8,16 @@ const (
 	// TunedDefaultResourceName is the name of the Node Tuning Operator's default custom tuned resource
 	TunedDefaultResourceName = "default"
 
+	// TunedRenderedResourceName is the name of the Node Tuning Operator's tuned resource combined out of
+	// all the other custom tuned resources
+	TunedRenderedResourceName = "rendered"
+
 	// TunedClusterOperatorResourceName is the name of the clusteroperator resource
 	// that reflects the node tuning operator status.
 	TunedClusterOperatorResourceName = "node-tuning"
 )
 
+/////////////////////////////////////////////////////////////////////////////////
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -88,7 +93,7 @@ type TunedList struct {
 	Items           []Tuned `json:"items"`
 }
 
-
+/////////////////////////////////////////////////////////////////////////////////
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
Recent NTO stops using ConfigMaps to communicate profile changes between
the operator and this operands.  This change adds support for the "rendered"
Tuned CR which is now used by the operator to inform the operand about
the global tuned profile changes.  Support for the old way of communicating
the changes (ConfigMaps) is still present, but will be removed soon.

Companion PR: https://github.com/openshift/cluster-node-tuning-operator/pull/98