### PR TITLE
Add component field to OWNERS file.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ reviewers:
   - jmencak
   - sjug
   - zvonkok
+component: "Node Tuning Operator"


### PR DESCRIPTION
The "component:" field is now required for all OpenShift GitHub repositories
which contribute directly to the product (i.e. they contain a Dockerfile or
.spec file which ART consumes).