### PR TITLE
Bug 1825007: Fix tuned reload behaviour on SIGHUP for invalid tuned profiles.

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/openshift-tuned
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.3:base
 ENV APP_ROOT=/var/lib/tuned
 ENV PATH=${APP_ROOT}/bin:${PATH}
 ENV HOME=${APP_ROOT}

--- a/assets/patches/020-fix_sighup_hang.diff
+++ b/assets/patches/020-fix_sighup_hang.diff
@@ -1,0 +1,144 @@
+From c044822affcf1fb21e4f4d26b18f73f152ea2a6d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Lyson=C4=9Bk?= <olysonek@redhat.com>
+Date: Tue, 26 Nov 2019 15:49:39 +0100
+Subject: [PATCH 1/3] Fix Traceback on reload when the preset profile does not
+ exist
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The reload_profile_config() method can pass through a TunedException
+when the requested profile does not exist, or is invalid. We need to
+catch it and log the error.
+
+Resolves: rhbz#1774645
+Resolves: rhbz#1702724
+
+Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>
+---
+ tuned/daemon/controller.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/daemon/controller.py b/daemon/controller.py
+index 5e1e9ba2..48c30ea6 100644
+--- a/daemon/controller.py
++++ b/daemon/controller.py
+@@ -138,7 +138,11 @@ def reload(self, caller = None):
+ 			stop_ok = self.stop()
+ 			if not stop_ok:
+ 				return False
+-			self._daemon.reload_profile_config()
++			try:
++				self._daemon.reload_profile_config()
++			except TunedException as e:
++				log.error("Failed to reload Tuned: %s" % e)
++				return False
+ 			return self.start()
+ 
+ 	def _switch_profile(self, profile_name, manual):
+
+From 5d8ef2c0095e999107574ebfb86e735bc048756e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Lyson=C4=9Bk?= <olysonek@redhat.com>
+Date: Tue, 26 Nov 2019 16:53:04 +0100
+Subject: [PATCH 2/3] Set manual profile mode on tuned-adm off
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To fix rhbz#1774645 and rhbz#1702724, we need to make the
+`Controller.reload` operation behave the same as a Tuned restart even
+in the case when Tuned is running but no profile is applied. If we did
+that, while setting automatic profile mode on `tuned-adm off` (as it
+is currently done), we would end up with a behaviour where `tuned-adm
+off` followed by controller reload would result in the recommended
+profile being applied.
+
+We agreed with Jaroslav that this behaviour wouldn't make sense, so we
+instead decided to change the behaviour of `tuned-adm off` followed by
+Tuned *restart*. Previously, it would result in the recommended
+profile being applied (which doesn't make much sense to us either). So
+we decided to change `tuned-adm off`, so that even after restart,
+Tuned runs with no profile applied, i.e. making `tuned-adm off` set
+manual profile mode.
+
+Related: rhbz#1774645
+Related: rhbz#1702724
+
+Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>
+---
+ tuned/daemon/controller.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/daemon/controller.py b/daemon/controller.py
+index 48c30ea6..5bd4d31a 100644
+--- a/daemon/controller.py
++++ b/daemon/controller.py
+@@ -219,7 +219,7 @@ def disable(self, caller = None):
+ 		if self._daemon.is_running():
+ 			self._daemon.stop()
+ 		if self._daemon.is_enabled():
+-			self._daemon.set_profile(None, None, save_instantly=True)
++			self._daemon.set_profile(None, True, save_instantly=True)
+ 		return True
+ 
+ 	@exports.export("", "b")
+
+From d545b13dc1e7568af42a59e9721033813eccb61a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Lyson=C4=9Bk?= <olysonek@redhat.com>
+Date: Wed, 27 Nov 2019 10:53:03 +0100
+Subject: [PATCH 3/3] controller: Proceed with reload even if daemon is not
+ running
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+To fix rhbz#1774645 and rhbz#1702724, we need to make the
+`Controller.reload` operation behave the same as a Tuned restart even
+in the case when Tuned is running but no profile is applied. To
+achieve that, we must not `return False` from `reload()` when Daemon
+is not running.
+
+I'm not aware of any specific purpose the `return False` could serve,
+other than perhaps making sure that running reload after `tuned-adm
+off` does not result in the recommended profile being applied. This
+case is handled in commit 5d8ef2c0095e9, so I think it should be safe
+now to drop the `return`.
+
+Resolves: rhbz#1774645
+Resolves: rhbz#1702724
+
+Signed-off-by: Ondřej Lysoněk <olysonek@redhat.com>
+---
+ tuned/daemon/controller.py | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/daemon/controller.py b/daemon/controller.py
+index 5bd4d31a..18e0bb61 100644
+--- a/daemon/controller.py
++++ b/daemon/controller.py
+@@ -132,18 +132,16 @@ def stop(self, caller = None):
+ 	def reload(self, caller = None):
+ 		if caller == "":
+ 			return False
+-		if not self._daemon.is_running():
+-			return False
+-		else:
++		if self._daemon.is_running():
+ 			stop_ok = self.stop()
+ 			if not stop_ok:
+ 				return False
+-			try:
+-				self._daemon.reload_profile_config()
+-			except TunedException as e:
+-				log.error("Failed to reload Tuned: %s" % e)
+-				return False
+-			return self.start()
++		try:
++			self._daemon.reload_profile_config()
++		except TunedException as e:
++			log.error("Failed to reload Tuned: %s" % e)
++			return False
++		return self.start()
+ 
+ 	def _switch_profile(self, profile_name, manual):
+ 		was_running = self._daemon.is_running()


### PR DESCRIPTION
This PR fixes the behaviour when reloading tuned daemon on SIGHUP.  Tuned pods
will now correctly display error messages from tuned pods when invalid tuned
profile is detected.  More importantly, upon correcting the custom tuned
profile the new profile itself will be reloaded.